### PR TITLE
Add :owner_id attribute to Company

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.10
+- add new field company.owner_id
+
 # 0.0.9
 - add new field (company/person).image_mobile_url
 

--- a/lib/pipeline_dealers/model/company.rb
+++ b/lib/pipeline_dealers/model/company.rb
@@ -20,11 +20,12 @@ module PipelineDealers
             :phone3,
             :phone4,
             :phone1_desc,
-            :phone2_desc, :phone3_desc,
+            :phone2_desc,
+            :phone3_desc,
             :phone4_desc,
             :created_at,
-            :import_id
-
+            :import_id,
+            :owner_id
 
       # Read only
       attrs :won_deals_total,
@@ -34,6 +35,7 @@ module PipelineDealers
             :total_pipeline,
             :possible_notify_user_ids,
             :state,
+            :owner,
         read_only: true
 
       def people

--- a/lib/pipeline_dealers/version.rb
+++ b/lib/pipeline_dealers/version.rb
@@ -1,3 +1,3 @@
 module PipelineDealers
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end


### PR DESCRIPTION
Without `:owner_id` finding a company throws the following exception: `The attribute :owner_id is not known by PipelineDealers::Model::Company!`