### PR TITLE
Add custom_field_group_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.11
+- add new field custom_field_group_id to Company::CustomField
+
 # 0.0.10
 - add new field company.owner_id
 

--- a/lib/pipeline_dealers/model/company/custom_field.rb
+++ b/lib/pipeline_dealers/model/company/custom_field.rb
@@ -3,6 +3,9 @@ module PipelineDealers
     class Company
       class CustomField < Model::CustomField
         self.collection_url = "admin/company_custom_field_labels"
+
+        attrs :custom_field_group_id,
+          readonly: true
       end
     end
   end

--- a/lib/pipeline_dealers/version.rb
+++ b/lib/pipeline_dealers/version.rb
@@ -1,3 +1,3 @@
 module PipelineDealers
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end


### PR DESCRIPTION
Fixes `PipelineDealers::Error::InvalidAttributeName: The attribute:custom_field_group_id is not known by PipelineDealers::Model::Company::CustomField!` exception`

Same kind of fix as in #4. 