### PR TITLE
Add missing attributes that are causing InvalidAttribute errors

### DIFF
--- a/lib/pipeline_dealers/model/custom_field.rb
+++ b/lib/pipeline_dealers/model/custom_field.rb
@@ -7,6 +7,9 @@ module PipelineDealers
             :created_at,
             :updated_at,
             :custom_field_label_dropdown_entries,
+            :report_behavior,
+            :position,
+            :type,
         readonly: true
 
       def decode(model, value)
@@ -67,7 +70,7 @@ module PipelineDealers
           dropdown: Dropdown,
           multi_select: MultiSelect,
           multi_association: Identity # Does not work yet
-        } 
+        }
       end
     end
   end


### PR DESCRIPTION
PipelineDeals has added some more attributes to the custom fields. This PR makes sure these are processed so they don't cause an `InvalidAttribute` error.