### PR TITLE
Add missing attributes for company

### DIFF
--- a/lib/pipeline_dealers/model/company.rb
+++ b/lib/pipeline_dealers/model/company.rb
@@ -25,7 +25,9 @@ module PipelineDealers
             :phone4_desc,
             :created_at,
             :import_id,
-            :owner_id
+            :owner_id,
+            :milestones,
+            :is_customer?
 
       # Read only
       attrs :won_deals_total,


### PR DESCRIPTION
This PR fixes some InvalidAttribute exceptions we got on `:milestone` and `is_customer?`.